### PR TITLE
REPO-2590: Added custom group admin react and templates to allow for user management

### DIFF
--- a/invenio_app_rdm/administration/groups/groups.py
+++ b/invenio_app_rdm/administration/groups/groups.py
@@ -72,7 +72,7 @@ class GroupsListView(AdminResourceListView):
     search_sort_config_name = "USERS_RESOURCES_GROUPS_SORT_OPTIONS"
     search_facets_config_name = "USERS_RESOURCES_GROUPS_SEARCH_FACETS"
     search_request_headers = {"Accept": "application/json"}
-    # template = "invenio_app_rdm/administration/users_search.html"
+    template = "invenio_app_rdm/administration/groups_search.html"
 
     # These actions are not connected on the frontend -
     # TODO: missing permission based links in resource
@@ -82,6 +82,21 @@ class GroupsListView(AdminResourceListView):
     def disabled():
         """Disable the view on demand."""
         return not current_app.config["USERS_RESOURCES_GROUPS_ENABLED"]
+
+    def init_search_config(self):
+        """Build search view config."""
+        return partial(
+            search_app_config,
+            config_name=self.get_search_app_name(),
+            available_facets=current_app.config.get(self.search_facets_config_name),
+            sort_options=current_app.config[self.search_sort_config_name],
+            endpoint=self.get_api_endpoint(),
+            headers=self.get_search_request_headers(),
+            initial_filters=[],
+            hidden_params=[],
+            pagination_options=(20, 50),
+            default_size=20,
+        )
 
 
 class GroupsDetailView(AdminResourceDetailView):

--- a/invenio_app_rdm/administration/templates/semantic-ui/invenio_app_rdm/administration/groups_search.html
+++ b/invenio_app_rdm/administration/templates/semantic-ui/invenio_app_rdm/administration/groups_search.html
@@ -1,0 +1,14 @@
+{#
+Copyright (C) 2023 CERN.
+
+Invenio App RDM is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends "invenio_administration/search.html" %}
+
+
+{% block javascript %}
+  {{ super() }}
+  {{ webpack['invenio-groups-administration.js'] }}
+{% endblock %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/ManageGroupUsers.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/ManageGroupUsers.js
@@ -1,0 +1,90 @@
+
+/*
+ * // This file is part of Invenio-App-Rdm
+ * // Copyright (C) 2023 CERN.
+ * //
+ * // Invenio-App-Rdm is free software; you can redistribute it and/or modify it
+ * // under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Modal, Icon, Dropdown } from "semantic-ui-react";
+import { ActionModal } from "@js/invenio_administration";
+import _isEmpty from "lodash/isEmpty";
+import { ManageGroupUsersForm } from "./ManageGroupUsersForm";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+
+export class ManageGroupUsers extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalOpen: false,
+      modalHeader: undefined,
+      modalBody: undefined,
+    };
+  }
+
+  onModalTriggerClick = (e) => {
+    const { group } = this.props;
+
+    this.setState({
+      modalOpen: true,
+      modalHeader: i18next.t("Manage user groups"),
+      modalBody: (
+        <ManageGroupUsersForm
+          actionCloseCallback={this.closeModal}
+          group={group}
+        />
+      ),
+    });
+  };
+
+  closeModal = () => {
+    this.setState({
+      modalOpen: false,
+      modalHeader: undefined,
+      modalBody: undefined,
+    });
+  };
+
+  handleSuccess = () => {
+    const { successCallback } = this.props;
+    this.setState({
+      modalOpen: false,
+      modalHeader: undefined,
+      modalBody: undefined,
+    });
+    successCallback();
+  };
+
+  render() {
+    const { group } = this.props;
+    const { modalOpen, modalHeader, modalBody } = this.state;
+    return (
+      <>
+        <Dropdown.Item
+          key="add-user-to-group"
+          onClick={this.onModalTriggerClick}
+          icon
+          fluid
+          basic
+          labelPosition="left"
+        >
+          <Icon name="spy" />
+          Manage Users
+        </Dropdown.Item>
+        <ActionModal modalOpen={modalOpen} group={group}>
+          {modalHeader && <Modal.Header>{modalHeader}</Modal.Header>}
+          {!_isEmpty(modalBody) && modalBody}
+        </ActionModal>
+      </>
+    );
+  }
+}
+
+ManageGroupUsers.propTypes = {
+  group: PropTypes.object.isRequired,
+};
+
+ManageGroupUsers.defaultProps = {};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/ManageGroupUsers.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/ManageGroupUsers.js
@@ -85,6 +85,7 @@ export class ManageGroupUsers extends Component {
 
 ManageGroupUsers.propTypes = {
   group: PropTypes.object.isRequired,
+  successCallback : PropTypes.func.isRequired,
 };
 
 ManageGroupUsers.defaultProps = {};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/GroupActions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/GroupActions.js
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022 CERN.
+ * Copyright (C) 2024 KTH Royal Institute of Technology.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import isEmpty from "lodash/isEmpty";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Button, Icon, Dropdown } from "semantic-ui-react";
+import { NotificationContext, Edit } from "@js/invenio_administration";
+import { withCancel } from "react-invenio-forms";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import { ManageGroupUsers } from "../components/ManageGroupUsers";
+
+export class GroupActions extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { loading: false };
+  }
+
+  componentWillUnmount() {
+    this.cancellableAction && this.cancellableAction.cancel();
+  }
+
+  static contextType = NotificationContext;
+
+  render() {
+    const {
+      group,
+      successCallback,
+      displayManageGroups,
+      displayEdit,
+      editUrl,
+      resource,
+      useDropdown,
+    } = this.props;
+    const { loading } = this.state;
+
+    const actionItems = [];
+
+    const generateActions = () => {
+      return (
+        <>
+          {displayManageGroups && (
+            <ManageGroupUsers
+              group={group}
+            />
+          )}
+        </>
+      );
+    };
+
+    return (
+      <div>
+        {useDropdown ? (
+          <div>
+            {displayEdit && <Edit editUrl={editUrl} resource={resource} />}
+            <Dropdown
+              text={<Icon name="cog" />}
+              tooltip={i18next.t("Actions")}
+              button
+              className="icon"
+              direction="left"
+            >
+            <Dropdown.Menu>{generateActions()}</Dropdown.Menu>
+            </Dropdown>
+          </div>
+        ) : (
+          <Button.Group basic widths={5} compact className="margined">
+            {generateActions()}
+          </Button.Group>
+        )}
+      </div>
+    );
+  }
+}
+
+GroupActions.propTypes = {
+  group: PropTypes.object.isRequired,
+  successCallback: PropTypes.func.isRequired,
+  displayManageGroups: PropTypes.bool,
+  displayEdit: PropTypes.bool,
+  editUrl: PropTypes.string,
+  resource: PropTypes.object,
+  useDropdown: PropTypes.bool,
+};
+
+GroupActions.defaultProps = {
+  displayManageGroups: false,
+  displayEdit: false,
+  useDropdown: false,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/api.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/api.js
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+import { APIRoutes } from "./routes";
+import { http } from "react-invenio-forms";
+
+const addUserToGroup = async (group, user_id) => {
+  return await http.put(APIRoutes.adduser(group, user_id));
+};
+
+const removeUserFromGroup = async (group, user_id) => {
+  return await http.delete(APIRoutes.removeuser(group, user_id));
+};
+
+const groupUsers = async (group) => {
+  return await http.get(APIRoutes.groupusers(group));
+};
+
+const groups = async () => {
+  return await http.get(APIRoutes.groups());
+};
+
+export const GroupModerationApi = {
+  addUserToGroup: addUserToGroup,
+  removeUserFromGroup: removeUserFromGroup,
+  groupUsers: groupUsers,
+  groups: groups
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/index.js
@@ -1,0 +1,8 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+export { GroupModerationApi } from "./api";

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/routes.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/api/routes.js
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import _get from "lodash/get";
+
+const APIRoutesGenerators = {
+
+  adduser: (group, user_id, idKeyPath = "id") => {
+    return `/api/groups/${_get(group, idKeyPath)}/users/${user_id}`;
+  },
+  
+  removeuser: (group, user_id, idKeyPath = "id") => {
+    return `/api/groups/${_get(group, idKeyPath)}/users/${user_id}`;
+  },
+
+  groupusers: (group, idKeyPath = "id") => {
+    return `/api/groups/${_get(group, idKeyPath)}/users`;
+  },
+
+  groups: () => {
+    return `/api/groups`;
+  },
+
+};
+export const APIRoutes = {
+  ...APIRoutesGenerators,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/index.js
@@ -1,0 +1,30 @@
+// This file is part of InvenioCommunities
+// Copyright (C) 2022 CERN.
+//
+// Invenio RDM is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { initDefaultSearchComponents } from "@js/invenio_administration";
+import { createSearchAppInit } from "@js/invenio_search_ui";
+import { NotificationController } from "@js/invenio_administration";
+import { SearchResultItemLayout, GroupSearchLayout } from "./search";
+import { SearchFacets } from "@js/invenio_administration";
+
+const domContainer = document.getElementById("invenio-search-config");
+
+const defaultComponents = initDefaultSearchComponents(domContainer);
+
+const overridenComponents = {
+  ...defaultComponents,
+  "InvenioAdministration.SearchResultItem.layout": SearchResultItemLayout,
+  "SearchApp.layout": GroupSearchLayout,
+  "SearchApp.facets": SearchFacets,
+};
+
+createSearchAppInit(
+  overridenComponents,
+  true,
+  "invenio-search-config",
+  false,
+  NotificationController
+);

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/GroupSearchLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/GroupSearchLayout.js
@@ -1,0 +1,68 @@
+/*
+ * // This file is part of Invenio-Requests
+ * // Copyright (C) 2023 CERN.
+ * //
+ * // Invenio-Requests is free software; you can redistribute it and/or modify it
+ * // under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { SearchAppResultsPane } from "@js/invenio_search_ui/components";
+import { SearchFacets } from "@js/invenio_administration";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { Sort } from "react-searchkit";
+import { Grid } from "semantic-ui-react";
+
+export class GroupSearchLayout extends Component {
+  render() {
+    const { config, appName } = this.props;
+    return (
+      <>
+        {/* auto column grid used instead of SUI grid for better searchbar width adjustment */}
+        <div className="auto-column-grid">
+          <div className="flex align-items-center column-mobile">
+            <div className="full-width flex align-items-center justify-end column-mobile">
+              {/*<SearchFilters customFilters={customFilters} />*/}
+              <Sort values={config.sortOptions} />
+            </div>
+          </div>
+        </div>
+        <div className="rel-mb-1">
+          {/*<FilterLabels ignoreFilters={["is_open"]} />*/}
+        </div>
+        <Grid>
+          <Grid.Column
+            computer={4}
+            mobile={16}
+            tablet={16}
+            largeScreen={2}
+            widescreen={2}
+          >
+            <SearchFacets aggs={config.aggs} appName={appName} />
+          </Grid.Column>
+          <Grid.Column
+            mobile={16}
+            tablet={16}
+            computer={12}
+            largeScreen={14}
+            widescreen={14}
+          >
+            <SearchAppResultsPane
+              layoutOptions={config.layoutOptions}
+              appName={appName}
+            />
+          </Grid.Column>
+        </Grid>
+      </>
+    );
+  }
+}
+
+GroupSearchLayout.propTypes = {
+  config: PropTypes.object.isRequired,
+  appName: PropTypes.string,
+};
+
+GroupSearchLayout.defaultProps = {
+  appName: "",
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/GroupSearchLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/GroupSearchLayout.js
@@ -23,7 +23,6 @@ export class GroupSearchLayout extends Component {
           <div className="flex align-items-center column-mobile">
             <div className="full-width flex align-items-center justify-end column-mobile">
               {/*<SearchFilters customFilters={customFilters} />*/}
-              <Sort values={config.sortOptions} />
             </div>
           </div>
         </div>
@@ -31,22 +30,7 @@ export class GroupSearchLayout extends Component {
           {/*<FilterLabels ignoreFilters={["is_open"]} />*/}
         </div>
         <Grid>
-          <Grid.Column
-            computer={4}
-            mobile={16}
-            tablet={16}
-            largeScreen={2}
-            widescreen={2}
-          >
-            <SearchFacets aggs={config.aggs} appName={appName} />
-          </Grid.Column>
-          <Grid.Column
-            mobile={16}
-            tablet={16}
-            computer={12}
-            largeScreen={14}
-            widescreen={14}
-          >
+          <Grid.Column>
             <SearchAppResultsPane
               layoutOptions={config.layoutOptions}
               appName={appName}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/SearchResultItemLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/SearchResultItemLayout.js
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2022-2024 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { BoolFormatter, DateFormatter, AdminUIRoutes} from "@js/invenio_administration";
+import { GroupActions } from "../GroupActions";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { Table, Dropdown, Icon } from "semantic-ui-react";
+import { withState } from "react-searchkit";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+
+class SearchResultItemComponent extends Component {
+  refreshAfterAction = () => {
+    const { updateQueryState, currentQueryState } = this.props;
+    updateQueryState(currentQueryState);
+  };
+
+  render() {
+    const { result, idKeyPath, listUIEndpoint } = this.props;
+
+    return (
+      <Table.Row>
+        {/*<Table.Cell>*/}
+        {/*We pass user ID to bulk actions - user moderation API takes user IDs*/}
+        {/*<SearchResultsRowCheckbox rowId={userId} data={result} />*/}
+        {/*</Table.Cell>*/}
+        <Table.Cell
+          collapsing
+          key={`group-id-${result.id}`}
+          data-label={i18next.t("Group")}
+          className="word-break-all"
+        >
+          {result.name}
+        </Table.Cell>
+        <Table.Cell
+          collapsing
+          key={`group-description-${result.id}`}
+          data-label={i18next.t("Description")}
+          className="word-break-all"
+        >
+          {result.description}
+        </Table.Cell>
+        <Table.Cell
+          collapsing
+          key={`group-is-managed-${result.id}`}
+          data-label={i18next.t("Is Managed")}
+          className="word-break-all"
+        >
+          <BoolFormatter
+            tooltip={i18next.t("Is Managed")}
+            icon="check"
+            color="green"
+            value={result.is_managed}
+          />
+        </Table.Cell>
+        <Table.Cell
+          collapsing
+          key={`group-created-${result.id}`}
+          data-label={i18next.t("Created")}
+          className="word-break-all"
+        >
+          <DateFormatter value={result.created} />
+        </Table.Cell>
+        <Table.Cell
+          collapsing
+          key={`group-updated-${result.id}`}
+          data-label={i18next.t("Updated")}
+          className="word-break-all"
+        >
+          <DateFormatter value={result.updated} />
+        </Table.Cell>
+        <Table.Cell collapsing>
+          <GroupActions
+            useDropdown
+            group={result}
+            successCallback={this.refreshAfterAction}
+            displayManageGroups
+            displayEdit
+            editUrl={AdminUIRoutes.editView(listUIEndpoint, result, idKeyPath)}
+            resource={result}
+          />
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+}
+
+SearchResultItemComponent.propTypes = {
+  result: PropTypes.object.isRequired,
+  idKeyPath: PropTypes.string.isRequired,
+  updateQueryState: PropTypes.func.isRequired,
+  currentQueryState: PropTypes.object.isRequired,
+  listUIEndpoint: PropTypes.string.isRequired,
+};
+
+SearchResultItemComponent.defaultProps = {};
+
+export const SearchResultItemLayout = withState(SearchResultItemComponent);

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/groups/search/index.js
@@ -1,0 +1,10 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+export { SearchResultItemLayout } from "./SearchResultItemLayout";
+export { GroupSearchLayout } from "./GroupSearchLayout";

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/api.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/api.js
@@ -44,8 +44,8 @@ const userGroups = async (user) => {
   return await http.get(APIRoutes.usergroups(user));
 };
 
-const groups = async () => {
-  return await http.get(APIRoutes.groups());
+const users = async () => {
+  return await http.get(APIRoutes.users());
 };
 
 export const UserModerationApi = {
@@ -58,5 +58,5 @@ export const UserModerationApi = {
   addGroupToUser: addGroupToUser,
   removeGroupFromUser: removeGroupFromUser,
   userGroups: userGroups,
-  groups: groups
+  users: users
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/routes.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/routes.js
@@ -45,9 +45,10 @@ const APIRoutesGenerators = {
     return `/api/users/${_get(user, idKeyPath)}/groups`;
   },
 
-  groups: () => {
-    return `/api/groups`;
+  users: () => {
+    return `/api/users`;
   },
+
 };
 export const APIRoutes = {
   ...APIRoutesGenerators,

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -39,6 +39,7 @@ theme = WebpackThemeBundle(
                 "invenio-drafts-administration": "./js/invenio_app_rdm/administration/drafts/index.js",
                 "invenio-domains-administration": "./js/invenio_app_rdm/administration/domains/index.js",
                 "invenio-communities-browse": "./js/invenio_app_rdm/subcommunity/browse.js",
+                "invenio-groups-administration": "./js/invenio_app_rdm/administration/groups/index.js",
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",


### PR DESCRIPTION
You can add and remove users in bulk from admin view, in the same way you can with the user admin for adding and removing groups to a user.
Group Admin Search view.

![Screenshot 2025-01-09 at 09 25 21](https://github.com/user-attachments/assets/7730fb09-0a70-4dc2-816b-0af00af18296)

Select Manage Users for a specific group
![Screenshot 2025-01-09 at 09 26 23](https://github.com/user-attachments/assets/35808f2e-5348-48eb-a68e-41b59dca3d4d)

Update associated users to group
![Screenshot 2025-01-09 at 09 25 36](https://github.com/user-attachments/assets/155aa80a-ea45-4ece-9668-4f463ce06d5d)
